### PR TITLE
Add remote_debugging_port for Windows WebView2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+prune src/flutter/flet_webview_all/build
+prune src/flutter/flet_webview_all/test

--- a/README.md
+++ b/README.md
@@ -84,6 +84,52 @@ page.add(
 | `javascript_enabled` | `bool` | `True` | Enables unrestricted JavaScript execution. |
 | `user_agent` | `str \| None` | `None` | Overrides the WebView user-agent when provided. |
 | `debugging_enabled` | `bool` | `False` | Prints JavaScript console messages through Flutter's debug logger. |
+| `remote_debugging_port` | `int \| None` | `None` | Windows-only, startup-time WebView2 CDP port (`1..65535`) for attaching Playwright to the visible WebView. |
+
+### Playwright on Windows
+
+On Windows, set `remote_debugging_port` on the first WebView. WebView2 uses one shared browser environment per process, so later WebViews inherit the same CDP endpoint. Any later control that explicitly specifies a port must use the same value. Changing the property after startup requires restarting the application.
+
+Remote debugging is intended for development and test automation. The CDP endpoint has no application-level authentication and can inspect every WebView in the shared environment, so leave `remote_debugging_port=None` in production.
+
+```python
+webview = FletWebviewAll(
+    url="https://example.com",
+    remote_debugging_port=9222,
+    expand=True,
+)
+page.add(webview)
+```
+
+Playwright can then attach to the exact WebView2 instance shown inside Flet:
+
+```python
+from playwright.async_api import async_playwright
+
+async def attach():
+    playwright = await async_playwright().start()
+    browser = await playwright.chromium.connect_over_cdp(
+        "http://127.0.0.1:9222"
+    )
+
+    pages = [
+        page
+        for context in browser.contexts
+        for page in context.pages
+    ]
+    for page in pages:
+        print(page.url)
+
+    page = next(
+        page for page in pages
+        if page.url.startswith("https://example.com")
+    )
+    print(await page.title())
+```
+
+Before connecting, `http://127.0.0.1:9222/json/list` should list the WebView2 page target.
+
+If another WebView2 controller is created before the control that specifies `remote_debugging_port`, WebView2 may already have initialized its shared environment and the port can no longer be enabled without restarting the application.
 
 Use `page.update()` after changing a control property at runtime:
 

--- a/docs/FletWebviewAll.md
+++ b/docs/FletWebviewAll.md
@@ -119,6 +119,27 @@ webview = FletWebviewAll(
 )
 ```
 
+### remote_debugging_port
+
+```
+remote_debugging_port: Optional[int] = None
+```
+
+Windows-only, startup-time WebView2 CDP port for attaching tools such as
+Playwright to the visible WebView. The value must be between 1 and 65535 and
+must be set on the first WebView. WebView2 shares one environment per process,
+so later controls that explicitly set a port must use the same value.
+
+```python
+webview = FletWebviewAll(
+    url="https://www.example.com",
+    remote_debugging_port=9222,
+)
+```
+
+Remote debugging is for development and test automation only. Leave the value
+as `None` in production.
+
 ## Inherited Properties
 
 As `FletWebviewAll` extends `LayoutControl`, it inherits the following categories of properties:
@@ -296,6 +317,7 @@ ft.run(main)
 - Requires Windows 10 or higher
 - WebView2 must be installed on the system
 - Full JavaScript support
+- Supports Playwright attachment through `remote_debugging_port`
 
 ### Web
 - Uses iframe for embedding

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ FletWebviewAll is a Flet extension that integrates the `webview_all` Flutter pac
 - **Zoom Support**: Built-in zoom controls for user convenience
 - **Custom User Agent**: Set custom user agent strings
 - **Debug Support**: Enable debugging for development and troubleshooting
+- **Playwright on Windows**: Attach to the visible WebView2 through a local CDP port
 
 ## Installation
 
@@ -92,6 +93,11 @@ ft.run(main)
 - **Type**: `bool`
 - **Default**: `False`
 - **Description**: Enable debugging for development purposes.
+
+### remote_debugging_port
+- **Type**: `Optional[int]`
+- **Default**: `None`
+- **Description**: Windows-only, startup-time WebView2 CDP port (`1..65535`) for Playwright attachment. Use only for development and testing.
 
 ## Layout Properties
 

--- a/examples/flet_webview_all_example/README.md
+++ b/examples/flet_webview_all_example/README.md
@@ -25,6 +25,16 @@ pip install -r requirements.txt
 flet run
 ```
 
+On Windows, opt in to the local WebView2 CDP endpoint before starting the app:
+
+```powershell
+$env:FLET_WEBVIEW_ALL_REMOTE_DEBUGGING_PORT = "9222"
+uv run flet run
+```
+
+Then verify that `http://127.0.0.1:9222/json/list` contains the visible
+WebView target. Do not enable this development-only endpoint in production.
+
 ### Building for Distribution
 
 Build for your target platform:

--- a/examples/flet_webview_all_example/src/main.py
+++ b/examples/flet_webview_all_example/src/main.py
@@ -1,3 +1,5 @@
+import os
+
 import flet as ft
 from flet_webview_all import FletWebviewAll
 
@@ -22,6 +24,8 @@ DEFAULT_HTML = """
 </body>
 </html>
 """
+
+REMOTE_DEBUGGING_PORT = os.getenv("FLET_WEBVIEW_ALL_REMOTE_DEBUGGING_PORT")
 
 
 def main(page: ft.Page):
@@ -96,6 +100,9 @@ def main(page: ft.Page):
         allow_navigation=allow_nav_switch.value,
         zoom_enabled=zoom_switch.value,
         javascript_enabled=js_switch.value,
+        remote_debugging_port=(
+            int(REMOTE_DEBUGGING_PORT) if REMOTE_DEBUGGING_PORT else None
+        ),
         expand=True,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,12 @@ Repository = "https://github.com/MyGithubAccount/flet-webview-all"
 Issues = "https://github.com/MyGithubAccount/flet-webview-all/issues"
 
 [tool.setuptools.package-data]
-"flutter.flet_webview_all" = ["**/*"]
+"flutter.flet_webview_all" = [
+    "pubspec.yaml",
+    "pubspec.lock",
+    "lib/*.dart",
+    "lib/**/*.dart",
+]
 
 [tool.setuptools]
 license-files = []

--- a/src/flet_webview_all/flet_webview_all.py
+++ b/src/flet_webview_all/flet_webview_all.py
@@ -19,6 +19,9 @@ class FletWebviewAll(ft.LayoutControl):
         javascript_enabled: Whether JavaScript is enabled (default: True)
         user_agent: Custom User-Agent string
         debugging_enabled: Whether debugging is enabled (default: False)
+        remote_debugging_port: Windows-only, startup-time WebView2 CDP port.
+            Must be between 1 and 65535. When set, Playwright can attach to
+            the same visible WebView with chromium.connect_over_cdp().
     """
 
     url: Optional[str] = None
@@ -28,3 +31,4 @@ class FletWebviewAll(ft.LayoutControl):
     javascript_enabled: bool = True
     user_agent: Optional[str] = None
     debugging_enabled: bool = False
+    remote_debugging_port: Optional[int] = None

--- a/src/flutter/flet_webview_all/lib/src/flet_webview_all.dart
+++ b/src/flutter/flet_webview_all/lib/src/flet_webview_all.dart
@@ -5,10 +5,7 @@ import 'webview_impl.dart';
 class FletWebviewAllControl extends StatelessWidget {
   final Control control;
 
-  const FletWebviewAllControl({
-    super.key,
-    required this.control,
-  });
+  const FletWebviewAllControl({super.key, required this.control});
 
   @override
   Widget build(BuildContext context) {
@@ -16,9 +13,12 @@ class FletWebviewAllControl extends StatelessWidget {
     String? html = control.getString("html");
     bool allowNavigation = control.getBool("allow_navigation", true) ?? true;
     bool zoomEnabled = control.getBool("zoom_enabled", true) ?? true;
-    bool javascriptEnabled = control.getBool("javascript_enabled", true) ?? true;
-    bool debuggingEnabled = control.getBool("debugging_enabled", false) ?? false;
+    bool javascriptEnabled =
+        control.getBool("javascript_enabled", true) ?? true;
+    bool debuggingEnabled =
+        control.getBool("debugging_enabled", false) ?? false;
     String? userAgent = control.getString("user_agent");
+    int? remoteDebuggingPort = control.getInt("remote_debugging_port");
 
     // Determine initial content - use url if available, otherwise html
     String initialContent = url ?? html ?? "about:blank";
@@ -31,6 +31,7 @@ class FletWebviewAllControl extends StatelessWidget {
       debuggingEnabled: debuggingEnabled,
       userAgent: userAgent,
       zoomEnabled: zoomEnabled,
+      remoteDebuggingPort: remoteDebuggingPort,
     );
 
     return LayoutControl(control: control, child: myControl);

--- a/src/flutter/flet_webview_all/lib/src/webview_environment.dart
+++ b/src/flutter/flet_webview_all/lib/src/webview_environment.dart
@@ -1,0 +1,10 @@
+import 'webview_environment_stub.dart'
+    if (dart.library.io) 'webview_environment_io.dart' as platform;
+
+/// Initializes platform-specific WebView process settings before the first
+/// WebViewController is constructed.
+Future<void> ensureWebViewEnvironment({required int remoteDebuggingPort}) {
+  return platform.ensureWebViewEnvironment(
+    remoteDebuggingPort: remoteDebuggingPort,
+  );
+}

--- a/src/flutter/flet_webview_all/lib/src/webview_environment_io.dart
+++ b/src/flutter/flet_webview_all/lib/src/webview_environment_io.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:webview_all_windows/webview_all_windows.dart';
+import 'webview_environment_manager.dart';
+
+final _environmentManager = WebViewEnvironmentManager(
+  initialize: (additionalArguments) =>
+      WindowsWebViewController.initializeEnvironment(
+    additionalArguments: additionalArguments,
+  ),
+);
+
+Future<void> ensureWebViewEnvironment({required int remoteDebuggingPort}) {
+  if (!Platform.isWindows) {
+    return Future<void>.value();
+  }
+
+  return _environmentManager.ensureInitialized(
+    remoteDebuggingPort: remoteDebuggingPort,
+  );
+}

--- a/src/flutter/flet_webview_all/lib/src/webview_environment_manager.dart
+++ b/src/flutter/flet_webview_all/lib/src/webview_environment_manager.dart
@@ -1,0 +1,60 @@
+typedef WebViewEnvironmentInitializer = Future<void> Function(
+    String additionalArguments);
+
+/// Coordinates the one-time configuration of the shared WebView2 environment.
+class WebViewEnvironmentManager {
+  WebViewEnvironmentManager({required WebViewEnvironmentInitializer initialize})
+      : _initialize = initialize;
+
+  final WebViewEnvironmentInitializer _initialize;
+
+  Future<void>? _initialization;
+  int? _configuredRemoteDebuggingPort;
+
+  Future<void> ensureInitialized({required int remoteDebuggingPort}) {
+    if (remoteDebuggingPort < 1 || remoteDebuggingPort > 65535) {
+      return Future<void>.error(
+        ArgumentError.value(
+          remoteDebuggingPort,
+          'remoteDebuggingPort',
+          'must be between 1 and 65535',
+        ),
+      );
+    }
+
+    final existingInitialization = _initialization;
+    if (existingInitialization != null) {
+      if (_configuredRemoteDebuggingPort != remoteDebuggingPort) {
+        return Future<void>.error(
+          StateError(
+            'WebView2 uses one shared environment per process. '
+            'It is already configured for remote debugging on port '
+            '$_configuredRemoteDebuggingPort and cannot be changed to '
+            '$remoteDebuggingPort without restarting the app.',
+          ),
+        );
+      }
+      return existingInitialization;
+    }
+
+    final additionalArguments = '--remote-debugging-port=$remoteDebuggingPort '
+        '--remote-debugging-address=127.0.0.1';
+
+    _configuredRemoteDebuggingPort = remoteDebuggingPort;
+
+    late final Future<void> initialization;
+    initialization = Future<void>.sync(() => _initialize(additionalArguments))
+        .onError((Object error, StackTrace stackTrace) {
+      // webview_all_windows supports retrying a failed environment startup.
+      // Do not keep returning the same failed Future forever.
+      if (identical(_initialization, initialization)) {
+        _initialization = null;
+        _configuredRemoteDebuggingPort = null;
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    });
+
+    _initialization = initialization;
+    return initialization;
+  }
+}

--- a/src/flutter/flet_webview_all/lib/src/webview_environment_stub.dart
+++ b/src/flutter/flet_webview_all/lib/src/webview_environment_stub.dart
@@ -1,0 +1,5 @@
+Future<void> ensureWebViewEnvironment({
+  required int remoteDebuggingPort,
+}) async {
+  // WebView2 remote debugging is Windows-only.
+}

--- a/src/flutter/flet_webview_all/lib/src/webview_impl.dart
+++ b/src/flutter/flet_webview_all/lib/src/webview_impl.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_all/webview_all.dart';
+import 'webview_environment.dart';
 
 /// Build a WebView widget for mobile and desktop platforms.
 Widget buildWebviewWidget({
@@ -11,8 +13,9 @@ Widget buildWebviewWidget({
   required bool debuggingEnabled,
   String? userAgent,
   bool zoomEnabled = true,
+  int? remoteDebuggingPort,
 }) {
-  return _WebviewAllWidget(
+  final webview = _WebviewAllWidget(
     initialContent: initialContent,
     javascriptEnabled: javascriptEnabled,
     allowNavigation: allowNavigation,
@@ -20,6 +23,77 @@ Widget buildWebviewWidget({
     userAgent: userAgent,
     zoomEnabled: zoomEnabled,
   );
+
+  if (remoteDebuggingPort == null ||
+      kIsWeb ||
+      defaultTargetPlatform != TargetPlatform.windows) {
+    return webview;
+  }
+
+  return _WebViewEnvironmentGate(
+    remoteDebuggingPort: remoteDebuggingPort,
+    child: webview,
+  );
+}
+
+class _WebViewEnvironmentGate extends StatefulWidget {
+  const _WebViewEnvironmentGate({
+    required this.remoteDebuggingPort,
+    required this.child,
+  });
+
+  final int remoteDebuggingPort;
+  final Widget child;
+
+  @override
+  State<_WebViewEnvironmentGate> createState() =>
+      _WebViewEnvironmentGateState();
+}
+
+class _WebViewEnvironmentGateState extends State<_WebViewEnvironmentGate> {
+  late Future<void> _initialization;
+
+  @override
+  void initState() {
+    super.initState();
+    _initialization = ensureWebViewEnvironment(
+      remoteDebuggingPort: widget.remoteDebuggingPort,
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant _WebViewEnvironmentGate oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.remoteDebuggingPort != widget.remoteDebuggingPort) {
+      _initialization = ensureWebViewEnvironment(
+        remoteDebuggingPort: widget.remoteDebuggingPort,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _initialization,
+      builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Center(
+            child: SelectableText(
+              'Failed to initialize WebView2 remote debugging: '
+              '${snapshot.error}',
+              textAlign: TextAlign.center,
+            ),
+          );
+        }
+
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        return widget.child;
+      },
+    );
+  }
 }
 
 class _WebviewAllWidget extends StatefulWidget {
@@ -191,8 +265,10 @@ class _ViewportSynchronizedWebViewState
       // that delayed transition on small windows and DPI changes.
       if (remaining > 1) {
         _pulseTimer?.cancel();
-        _pulseTimer = Timer(const Duration(milliseconds: 32),
-            () => _pulseViewport(remaining - 1));
+        _pulseTimer = Timer(
+          const Duration(milliseconds: 32),
+          () => _pulseViewport(remaining - 1),
+        );
       }
     });
   }
@@ -215,13 +291,9 @@ class _ViewportSynchronizedWebViewState
           // One physical pixel is enough to make the package call its native
           // SetSurfaceSize method, while being imperceptible to the user.
           padding: EdgeInsets.only(
-            right: _nudgeViewport
-                ? 1 / View.of(context).devicePixelRatio
-                : 0,
+            right: _nudgeViewport ? 1 / View.of(context).devicePixelRatio : 0,
           ),
-          child: WebViewWidget(
-            controller: widget.controller,
-          ),
+          child: WebViewWidget(controller: widget.controller),
         ),
       ),
     );

--- a/src/flutter/flet_webview_all/lib/src/webview_stub.dart
+++ b/src/flutter/flet_webview_all/lib/src/webview_stub.dart
@@ -8,6 +8,7 @@ Widget buildWebviewWidget({
   required bool debuggingEnabled,
   String? userAgent,
   bool zoomEnabled = true,
+  int? remoteDebuggingPort,
 }) {
   // Extract URL from initialContent for display
   String? displayUrl;

--- a/src/flutter/flet_webview_all/pubspec.lock
+++ b/src/flutter/flet_webview_all/pubspec.lock
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "11.0.3"
   fixnum:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: "direct main"
     description:
       name: flet
-      sha256: "89585ffebc89d7586c7fbc00adea84688b118ee8b4deb2f1210d54c67669857b"
+      sha256: "6f00a27865030dc740b2f4211e147ac1d45eb48dc2bae93951505e61ead4bd6e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.85.2"
+    version: "0.86.5"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -401,10 +401,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -473,10 +473,10 @@ packages:
     dependency: transitive
     description:
       name: pasteboard
-      sha256: "9ff73ada33f79a59ff91f6c01881fd4ed0a0031cfc4ae2d86c0384471525fca1"
+      sha256: fedbe8da188d2f713aa8b01260737342e6e1087534a3ab26e1a719f8d3e8f32f
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.5.0"
   path:
     dependency: transitive
     description:
@@ -593,58 +593,58 @@ packages:
     dependency: transitive
     description:
       name: screen_brightness
-      sha256: "7ea1c037422f007f022dcff3ee955bf8e61a474d5426b29be9290fd976c3e46b"
+      sha256: e0edf92c08889e8f493cde291e7c687db2b4a1471f2371c074070b75d7c7d79b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.9"
+    version: "2.1.11"
   screen_brightness_android:
     dependency: transitive
     description:
       name: screen_brightness_android
-      sha256: "0e4b0a07d5f730b91a8780d8436f3a92be8a8cc2066032ed88b93c8fa153fadf"
+      sha256: "2008ad8e9527cc968f7a4de1ec58b476d495b3c612a149dbd6550c4f046da147"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   screen_brightness_ios:
     dependency: transitive
     description:
       name: screen_brightness_ios
-      sha256: "0792d8f98852558f831b4b75241c46047b884598b3f4d982b37dc2dd43e2b2e1"
+      sha256: "352d355e8523a186ba1e494b74218e5ca96e51975a0630b8ed89fbb7ff609762"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   screen_brightness_macos:
     dependency: transitive
     description:
       name: screen_brightness_macos
-      sha256: "278712cf5288db57bd335968cbfb2ec5441028f1ee2fcbdc8d1582d8210a3442"
+      sha256: b0957237b842d846a84363b69f229b339a8f91faced55041e245b2ebff7b0142
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   screen_brightness_ohos:
     dependency: transitive
     description:
       name: screen_brightness_ohos
-      sha256: "33f495741d5aa53104d3f5875dcb4b6a119f29ef595be17129ee03a5b78e76a9"
+      sha256: "569a2c97909a50894b81487619eb7654f5358443a5af05f840c19261f49c0940"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   screen_brightness_platform_interface:
     dependency: transitive
     description:
       name: screen_brightness_platform_interface
-      sha256: "59d50850d6735d677780fc7359c8e997d0ff6df91c8465161c9e617a7b0a11d8"
+      sha256: "2de60c0ba569b898950029cc1f7e9dd72bda44a22beb5054aac331cb6fce2ff2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   screen_brightness_windows:
     dependency: transitive
     description:
       name: screen_brightness_windows
-      sha256: "121f9dd6d62585bfb4e468c2170804ce4f2a2303ae6b2efc3a065c94937505d7"
+      sha256: "368b9c822e1671de81616e48150006e39eff2a434957e47ee638b09a32b2297c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   screen_retriever:
     dependency: transitive
     description:
@@ -838,10 +838,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   tuple:
     dependency: transitive
     description:
@@ -1022,58 +1022,66 @@ packages:
     dependency: "direct main"
     description:
       name: webview_all
-      sha256: e66f1a2d820a44b053d4b76d34091b3f696355649b51a09de4a7d5c8765213d6
+      sha256: "0ef82a67b481ed4b63677359a2d977d58eb807cc6f90f0570736425150bc1b75"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.4.0"
+  webview_all_android:
+    dependency: transitive
+    description:
+      name: webview_all_android
+      sha256: d46ef01e8d2358f11487eb0442a7caed2551cbffbfefd6f44b7b79797fcab2ac
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   webview_all_linux:
     dependency: transitive
     description:
       name: webview_all_linux
-      sha256: "328d63ec38d4f0626fd0f7eec9ad47601cff4874b28d6ef56bbd0d663d206caf"
+      sha256: dd31aa2d0aa709019a36697c694a2e0df6dd1c8c14ced12bf06539e175710f98
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.4"
+    version: "1.4.0"
+  webview_all_ohos:
+    dependency: transitive
+    description:
+      name: webview_all_ohos
+      sha256: ae825205c4fa752123145c3eb191e220ef0455ab3107ac10c62e1246679bd444
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   webview_all_web:
     dependency: transitive
     description:
       name: webview_all_web
-      sha256: "0dafb1163de9dce06a3bc0f9f11190ac6da9d6033b46410e1b8ff15aae98d8e1"
+      sha256: "35cbef8acea09d12b927e396e483b112ba4030b71d428470fd5d61f39881b189"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "1.4.0"
   webview_all_windows:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_all_windows
-      sha256: "6bcd9173ea709976005c96dcef75d596d6e2a58192e859f574d305dbee9954b6"
+      sha256: "919e759efe39a668cb483447cd6f29880de1bc2d48d50c67178561902d27b6f1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
-  webview_flutter_android:
+    version: "1.4.0"
+  webview_all_wkwebview:
     dependency: transitive
     description:
-      name: webview_flutter_android
-      sha256: ad5182eff9a550925330cb9f0cb038eddfdd5712aba8b77aa0f0400e50f6e688
+      name: webview_all_wkwebview
+      sha256: "47562b7300b021e6e0eedaf2322b5d1cff96d6c1120cf0fbc9b6246312562df8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.12.0"
-  webview_flutter_platform_interface:
+    version: "1.4.0"
+  webview_platform_interface:
     dependency: transitive
     description:
-      name: webview_flutter_platform_interface
-      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
+      name: webview_platform_interface
+      sha256: "0f550d73eba8ebf9223aeca5f3eaac12848a2dcaa07ad619e4ff7d0b539740b7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.1"
-  webview_flutter_wkwebview:
-    dependency: transitive
-    description:
-      name: webview_flutter_wkwebview
-      sha256: "82648217f537573e1ca9ae9952d3eacedca6ab5aee69dc84445fc763766dcea2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.25.1"
+    version: "1.4.0"
   win32:
     dependency: transitive
     description:
@@ -1098,14 +1106,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
-  window_to_front:
-    dependency: transitive
-    description:
-      name: window_to_front
-      sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/src/flutter/flet_webview_all/pubspec.yaml
+++ b/src/flutter/flet_webview_all/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   webview_all: ^1.3.3
+  webview_all_windows: ^1.3.3
 
 dev_dependencies:
   flutter_test:

--- a/src/flutter/flet_webview_all/test/webview_environment_manager_test.dart
+++ b/src/flutter/flet_webview_all/test/webview_environment_manager_test.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+
+import 'package:flet_webview_all/src/webview_environment_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('WebViewEnvironmentManager', () {
+    test('rejects ports outside the TCP range', () async {
+      var initializationCount = 0;
+      final manager = WebViewEnvironmentManager(
+        initialize: (_) {
+          initializationCount++;
+          return Future<void>.value();
+        },
+      );
+
+      for (final port in <int>[-1, 0, 65536]) {
+        await expectLater(
+          manager.ensureInitialized(remoteDebuggingPort: port),
+          throwsA(isA<ArgumentError>()),
+        );
+      }
+
+      expect(initializationCount, 0);
+    });
+
+    test('passes loopback-only CDP arguments to WebView2', () async {
+      String? receivedArguments;
+      final manager = WebViewEnvironmentManager(
+        initialize: (additionalArguments) {
+          receivedArguments = additionalArguments;
+          return Future<void>.value();
+        },
+      );
+
+      await manager.ensureInitialized(remoteDebuggingPort: 9222);
+
+      expect(
+        receivedArguments,
+        '--remote-debugging-port=9222 '
+        '--remote-debugging-address=127.0.0.1',
+      );
+    });
+
+    test(
+      'shares one initialization for concurrent requests to the same port',
+      () async {
+        final initialization = Completer<void>();
+        var initializationCount = 0;
+        final manager = WebViewEnvironmentManager(
+          initialize: (_) {
+            initializationCount++;
+            return initialization.future;
+          },
+        );
+
+        final first = manager.ensureInitialized(remoteDebuggingPort: 9222);
+        final second = manager.ensureInitialized(remoteDebuggingPort: 9222);
+
+        expect(identical(first, second), isTrue);
+        expect(initializationCount, 1);
+
+        initialization.complete();
+        await Future.wait(<Future<void>>[first, second]);
+      },
+    );
+
+    test('rejects a different port after initialization starts', () async {
+      final initialization = Completer<void>();
+      final manager = WebViewEnvironmentManager(
+        initialize: (_) => initialization.future,
+      );
+
+      final first = manager.ensureInitialized(remoteDebuggingPort: 9222);
+
+      await expectLater(
+        manager.ensureInitialized(remoteDebuggingPort: 9333),
+        throwsA(isA<StateError>()),
+      );
+
+      initialization.complete();
+      await first;
+    });
+
+    test('allows the same port to retry after asynchronous failure', () async {
+      var attempts = 0;
+      final manager = WebViewEnvironmentManager(
+        initialize: (_) {
+          attempts++;
+          if (attempts == 1) {
+            return Future<void>.error(StateError('temporary failure'));
+          }
+          return Future<void>.value();
+        },
+      );
+
+      await expectLater(
+        manager.ensureInitialized(remoteDebuggingPort: 9222),
+        throwsA(isA<StateError>()),
+      );
+      await manager.ensureInitialized(remoteDebuggingPort: 9222);
+
+      expect(attempts, 2);
+    });
+
+    test(
+      'converts synchronous initialization errors into Future errors',
+      () async {
+        var attempts = 0;
+        final manager = WebViewEnvironmentManager(
+          initialize: (_) {
+            attempts++;
+            if (attempts == 1) {
+              throw StateError('synchronous failure');
+            }
+            return Future<void>.value();
+          },
+        );
+
+        final failedInitialization = manager.ensureInitialized(
+          remoteDebuggingPort: 9222,
+        );
+
+        await expectLater(failedInitialization, throwsA(isA<StateError>()));
+        await manager.ensureInitialized(remoteDebuggingPort: 9222);
+
+        expect(attempts, 2);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Expose remote_debugging_port on FletWebviewAll to enable WebView2 CDP attachment on Windows. Adds Flutter wiring (control property, webview environment gate), platform-specific environment initializers and a WebViewEnvironmentManager to enforce a single shared environment and port validation. Updates docs, README, example (FLET_WEBVIEW_ALL_REMOTE_DEBUGGING_PORT), pyproject package-data, pubspecs, and .gitignore. Adds tests for the environment manager and related new Dart files to handle initialization and error/retry semantics.